### PR TITLE
fix: enable outer IP fragmentation and preserve TAP MTU

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,8 +3,7 @@ name: Build and Release
 on:
   push:
     branches: [ "main" ]
-  pull_request:
-    branches: [ "main" ]
+  workflow_dispatch:
 
 permissions:
   contents: write

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 *.o
 etherip
+/tmp
+.DS_Store

--- a/platform/linux/socket.c
+++ b/platform/linux/socket.c
@@ -26,14 +26,15 @@ extern int sock_open(int *fd, int domain, struct sockaddr_storage *addr, socklen
         }
     }
 
-    if(domain == AF_INET6){
-        int pmtu6 = IPV6_PMTUDISC_DONT;
-        if(setsockopt(*fd, IPPROTO_IPV6, IPV6_MTU_DISCOVER, &pmtu6, sizeof(pmtu6)) == -1){
-            fprintf(stderr, "[ERROR]: Failed to disable IPv6 PMTU discovery: %s\n", strerror(errno));
-            close(*fd);
-            return -1;
-        }
-    }
+    // Note: By disabling PMTU discovery for IPv6, the encapsulated packets will be fragmented 1280bytes even if the underlay MTU is larger. 
+    // if(domain == AF_INET6){
+    //     int pmtu6 = IPV6_PMTUDISC_DONT;
+    //     if(setsockopt(*fd, IPPROTO_IPV6, IPV6_MTU_DISCOVER, &pmtu6, sizeof(pmtu6)) == -1){
+    //         fprintf(stderr, "[ERROR]: Failed to disable IPv6 PMTU discovery: %s\n", strerror(errno));
+    //         close(*fd);
+    //         return -1;
+    //     }
+    // }
 
     if(bind(*fd, (struct sockaddr *)addr, addr_len) == -1){
         fprintf(stderr, "[ERROR]: Failed to bind socket: %s\n", strerror(errno));

--- a/platform/linux/socket.c
+++ b/platform/linux/socket.c
@@ -3,6 +3,8 @@
 #include <string.h>
 #include <sys/socket.h>
 #include <arpa/inet.h>
+#include <netinet/in.h>
+#include <netinet/ip6.h>
 #include <unistd.h>
 
 #include "socket.h"
@@ -13,6 +15,24 @@ extern int sock_open(int *fd, int domain, struct sockaddr_storage *addr, socklen
     if(*fd == -1){
         fprintf(stderr, "[ERROR]: Failed to open socket: %s\n", strerror(errno));
         return -1;
+    }
+
+    if(domain == AF_INET){
+        int pmtu_discover = IP_PMTUDISC_DONT;
+        if(setsockopt(*fd, IPPROTO_IP, IP_MTU_DISCOVER, &pmtu_discover, sizeof(pmtu_discover)) == -1){
+            fprintf(stderr, "[ERROR]: Failed to disable IPv4 PMTU discovery: %s\n", strerror(errno));
+            close(*fd);
+            return -1;
+        }
+    }
+
+    if(domain == AF_INET6){
+        int pmtu6 = IPV6_PMTUDISC_DONT;
+        if(setsockopt(*fd, IPPROTO_IPV6, IPV6_MTU_DISCOVER, &pmtu6, sizeof(pmtu6)) == -1){
+            fprintf(stderr, "[ERROR]: Failed to disable IPv6 PMTU discovery: %s\n", strerror(errno));
+            close(*fd);
+            return -1;
+        }
     }
 
     if(bind(*fd, (struct sockaddr *)addr, addr_len) == -1){

--- a/platform/linux/tap.c
+++ b/platform/linux/tap.c
@@ -33,12 +33,7 @@ extern int tap_open(int *fd, char name[], int mtu, int domain){
         return -1;
     }
 
-    if(domain == AF_INET){
-        ifr.ifr_mtu = mtu - IPv4_HEADER_LEN - ETHERIP_HEADER_LEN - ETHER_HEADER_LEN;
-    }
-    else if(domain == AF_INET6){
-        ifr.ifr_mtu = mtu - IPv6_HEADER_LEN - ETHERIP_HEADER_LEN - ETHER_HEADER_LEN;
-    }
+    ifr.ifr_mtu = mtu;
     if(ioctl(socket(AF_INET, SOCK_DGRAM, 0), SIOCSIFMTU, &ifr) == -1){
         fprintf(stderr, "[ERROR]: Failed to SIOCSIFMTU: %s\n", strerror(errno));
         close(*fd);

--- a/tests/integration/README.md
+++ b/tests/integration/README.md
@@ -26,6 +26,8 @@ sudo tests/integration/run_netns_tests.sh
 
 Notes
 - The ping test uses `ping -M do -s 1472` to send an inner IP packet of 1500 bytes (20B IP + 8B ICMP + 1472 payload = 1500). DF is set on the inner packet; fragmentation of the outer (encapsulated) packet is allowed.
+ - The ping test uses `ping -M do -s 1472` to send an inner IP packet of 1500 bytes (20B IP + 8B ICMP + 1472 payload = 1500). DF is set on the inner packet; fragmentation of the outer (encapsulated) packet is allowed.
+ - IPv6 test: The script also runs an IPv6 mode test after the IPv4 test. It uses `ping -6 -M do -s 1452` to produce a 1500-byte inner IPv6 packet (40B IPv6 header + 8B ICMPv6 + 1452 payload = 1500).
 - To point to a custom `etherip` binary path, set `ETHERIP_BIN` before running:
 ```bash
 export ETHERIP_BIN=/path/to/etherip

--- a/tests/integration/README.md
+++ b/tests/integration/README.md
@@ -14,7 +14,7 @@ Prerequisites
 
 Files
 - `tests/integration/setup_netns.sh` — create/destroy namespaces, veth pairs, and TAPs
-- `tests/integration/run_netns_tests.sh` — start two `etherip` instances, run `ping` with DF, optional `iperf3`, then cleanup
+- `tests/integration/run_netns_tests.sh` — start two `etherip` instances, run `ping` with DF, optional `iperf3`, save logs under `~/tmp`, capture EtherIP packets with `tcpdump`, then cleanup
 
 Quick start
 ```bash
@@ -34,6 +34,8 @@ export ETHERIP_BIN=/path/to/etherip
 sudo tests/integration/run_netns_tests.sh
 ```
 - Logs are stored under `/tmp/etherip-test-<pid>` and the script prints the path on completion.
+- Logs are stored under `./tmp/etherip-test-<pid>` by default. Override with `ETHERIP_LOGBASE=/some/path`.
+- The script saves packet captures as `ns1-etherip.pcap` and `ns2-etherip.pcap` in the log directory.
 
 CI
 - These tests require privileged operations and are not suitable for unprivileged CI runners. Run them on a privileged runner or dedicated test host.

--- a/tests/integration/run_netns_tests.sh
+++ b/tests/integration/run_netns_tests.sh
@@ -2,12 +2,26 @@
 set -euo pipefail
 SCRIPTDIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 ETHERIP_BIN="${ETHERIP_BIN:-$(pwd)/etherip}"
-ETHERIP_MTU="${ETHERIP_MTU:-1536}"
-LOGDIR="/tmp/etherip-test-$$"
+ETHERIP_MTU="${ETHERIP_MTU:-1500}"
+LOGBASE="${ETHERIP_LOGBASE:-./tmp}"
+LOGDIR="$LOGBASE/etherip-test-$$"
 mkdir -p "$LOGDIR"
+
+TCPDUMP_FILTER="proto 97"
+
+cleanup() {
+  if [ -f "$LOGDIR/tcpdump-ns1.pid" ]; then sudo kill "$(cat "$LOGDIR/tcpdump-ns1.pid")" || true; fi
+  if [ -f "$LOGDIR/tcpdump-ns2.pid" ]; then sudo kill "$(cat "$LOGDIR/tcpdump-ns2.pid")" || true; fi
+}
+
+trap cleanup EXIT
 
 # 1) setup
 sudo "$SCRIPTDIR/setup_netns.sh" create
+
+# capture outer EtherIP packets for the whole test run
+sudo ip netns exec ns1 tcpdump -i veth1 -s 0 -U -w "$LOGDIR/ns1-etherip.pcap" "$TCPDUMP_FILTER" > "$LOGDIR/tcpdump-ns1.log" 2>&1 & echo $! > "$LOGDIR/tcpdump-ns1.pid"
+sudo ip netns exec ns2 tcpdump -i veth2 -s 0 -U -w "$LOGDIR/ns2-etherip.pcap" "$TCPDUMP_FILTER" > "$LOGDIR/tcpdump-ns2.log" 2>&1 & echo $! > "$LOGDIR/tcpdump-ns2.pid"
 
 # 2) start etherip in each ns (background) - IPv4
 
@@ -16,7 +30,7 @@ sudo ip netns exec ns2 bash -c "cd /workspaces/etherip || cd /; $ETHERIP_BIN --m
 
 sleep 1
 
-# MTU/DF test (IPv4): etherip --mtu 1536 gives tap MTU 1500 on IPv4.
+# MTU/DF test (IPv4): etherip --mtu 1500 gives tap MTU 1500 on IPv4.
 echo "Running ping with DF (no-fragment) on inner packet from ns1 -> ns2 (ICMP payload 1472 => 1500-byte inner IP packets)"
 sudo ip netns exec ns1 ping -M do -c 4 -s 1472 192.168.200.2 > "$LOGDIR/ping.out" 2>&1 || true
 cat "$LOGDIR/ping.out"
@@ -45,7 +59,7 @@ if [ -f "$LOGDIR/etherip-ns2.pid" ]; then sudo kill "$(cat "$LOGDIR/etherip-ns2.
 ######################
 # IPv6 test
 ######################
-ETHERIP_MTU_V6="${ETHERIP_MTU_V6:-1556}"
+ETHERIP_MTU_V6="${ETHERIP_MTU_V6:-1500}"
 echo "Starting IPv6 etherip instances (mtu=$ETHERIP_MTU_V6)"
 # use outer veth IPv6 addresses for encapsulation
 sudo ip netns exec ns1 bash -c "cd /workspaces/etherip || cd /; $ETHERIP_BIN --mtu $ETHERIP_MTU_V6 ipv6 dst 2001:db8:1::2 src 2001:db8:1::1 tap tap1 > $LOGDIR/etherip-ns1-v6.log 2>&1 & echo \$! > $LOGDIR/etherip-ns1-v6.pid"
@@ -79,6 +93,7 @@ fi
 # final cleanup: kill any remaining etherip processes and destroy namespaces
 if [ -f "$LOGDIR/etherip-ns1-v6.pid" ]; then sudo kill "$(cat "$LOGDIR/etherip-ns1-v6.pid")" || true; fi
 if [ -f "$LOGDIR/etherip-ns2-v6.pid" ]; then sudo kill "$(cat "$LOGDIR/etherip-ns2-v6.pid")" || true; fi
+cleanup
 sudo "$SCRIPTDIR/setup_netns.sh" destroy
 
 echo "Logs: $LOGDIR"

--- a/tests/integration/run_netns_tests.sh
+++ b/tests/integration/run_netns_tests.sh
@@ -9,15 +9,14 @@ mkdir -p "$LOGDIR"
 # 1) setup
 sudo "$SCRIPTDIR/setup_netns.sh" create
 
-# 2) start etherip in each ns (background)
+# 2) start etherip in each ns (background) - IPv4
+
 sudo ip netns exec ns1 bash -c "cd /workspaces/etherip || cd /; $ETHERIP_BIN --mtu $ETHERIP_MTU ipv4 dst 10.10.10.2 src 10.10.10.1 tap tap1 > $LOGDIR/etherip-ns1.log 2>&1 & echo \$! > $LOGDIR/etherip-ns1.pid"
 sudo ip netns exec ns2 bash -c "cd /workspaces/etherip || cd /; $ETHERIP_BIN --mtu $ETHERIP_MTU ipv4 dst 10.10.10.1 src 10.10.10.2 tap tap2 > $LOGDIR/etherip-ns2.log 2>&1 & echo \$! > $LOGDIR/etherip-ns2.pid"
 
 sleep 1
 
-# MTU/DF test:
-# etherip --mtu 1536 gives tap MTU 1500 on IPv4, so an ICMP payload of 1472
-# creates a 1500-byte inner IP packet. DF is set on the inner packet.
+# MTU/DF test (IPv4): etherip --mtu 1536 gives tap MTU 1500 on IPv4.
 echo "Running ping with DF (no-fragment) on inner packet from ns1 -> ns2 (ICMP payload 1472 => 1500-byte inner IP packets)"
 sudo ip netns exec ns1 ping -M do -c 4 -s 1472 192.168.200.2 > "$LOGDIR/ping.out" 2>&1 || true
 cat "$LOGDIR/ping.out"
@@ -39,9 +38,47 @@ else
   echo "iperf3 not found; skipping throughput test"
 fi
 
-# cleanup etherip processes and namespaces
+# stop ipv4 etherip instances but keep namespaces for ipv6 test
 if [ -f "$LOGDIR/etherip-ns1.pid" ]; then sudo kill "$(cat "$LOGDIR/etherip-ns1.pid")" || true; fi
 if [ -f "$LOGDIR/etherip-ns2.pid" ]; then sudo kill "$(cat "$LOGDIR/etherip-ns2.pid")" || true; fi
+
+######################
+# IPv6 test
+######################
+ETHERIP_MTU_V6="${ETHERIP_MTU_V6:-1556}"
+echo "Starting IPv6 etherip instances (mtu=$ETHERIP_MTU_V6)"
+# use outer veth IPv6 addresses for encapsulation
+sudo ip netns exec ns1 bash -c "cd /workspaces/etherip || cd /; $ETHERIP_BIN --mtu $ETHERIP_MTU_V6 ipv6 dst 2001:db8:1::2 src 2001:db8:1::1 tap tap1 > $LOGDIR/etherip-ns1-v6.log 2>&1 & echo \$! > $LOGDIR/etherip-ns1-v6.pid"
+sudo ip netns exec ns2 bash -c "cd /workspaces/etherip || cd /; $ETHERIP_BIN --mtu $ETHERIP_MTU_V6 ipv6 dst 2001:db8:1::1 src 2001:db8:1::2 tap tap2 > $LOGDIR/etherip-ns2-v6.log 2>&1 & echo \$! > $LOGDIR/etherip-ns2-v6.pid"
+
+sleep 1
+
+# IPv6 MTU/DF test: inner IPv6 packet 1500 bytes => payload = 1500 - 40 - 8 = 1452
+echo "Running ping6 with DF (no-fragment) on inner IPv6 packet from ns1 -> ns2 (ICMPv6 payload 1452 => 1500-byte inner IPv6 packets)"
+# ping the inner TAP IPv6 address
+sudo ip netns exec ns1 ping -6 -M do -c 4 -s 1452 2001:db8:200::2 > "$LOGDIR/ping6.out" 2>&1 || true
+cat "$LOGDIR/ping6.out"
+if grep -q '0% packet loss' "$LOGDIR/ping6.out"; then
+  echo "PING6 DF: success (inner 1500-byte IPv6 packet traversed)"
+else
+  echo "PING6 DF: failed or partial loss"
+fi
+
+if command -v iperf3 >/dev/null 2>&1; then
+  echo "Starting iperf3 server in ns2 (IPv6)"
+  sudo ip netns exec ns2 iperf3 -s -V > "$LOGDIR/iperf-server-v6.log" 2>&1 & echo $! > "$LOGDIR/iperf-server-v6.pid"
+  sleep 1
+  echo "Running iperf3 client from ns1 -> ns2 (IPv6, 10s)"
+  # force IPv6 and connect to the inner TAP IPv6 address
+  sudo ip netns exec ns1 iperf3 -6 -c 2001:db8:200::2 -t 10 -P 2 | tee "$LOGDIR/iperf-client-v6.out"
+  sudo kill "$(cat "$LOGDIR/iperf-server-v6.pid")" || true
+else
+  echo "iperf3 not found; skipping IPv6 throughput test"
+fi
+
+# final cleanup: kill any remaining etherip processes and destroy namespaces
+if [ -f "$LOGDIR/etherip-ns1-v6.pid" ]; then sudo kill "$(cat "$LOGDIR/etherip-ns1-v6.pid")" || true; fi
+if [ -f "$LOGDIR/etherip-ns2-v6.pid" ]; then sudo kill "$(cat "$LOGDIR/etherip-ns2-v6.pid")" || true; fi
 sudo "$SCRIPTDIR/setup_netns.sh" destroy
 
 echo "Logs: $LOGDIR"

--- a/tests/integration/setup_netns.sh
+++ b/tests/integration/setup_netns.sh
@@ -33,8 +33,15 @@ create() {
   ip netns exec $NS1 ip link set dev veth1 up
   ip netns exec $NS2 ip link set dev veth2 up
 
+  ip netns exec $NS1 ip link set dev veth1 mtu 1500
+  ip netns exec $NS2 ip link set dev veth2 mtu 1500
+
   ip netns exec $NS1 ip addr add 10.10.10.1/24 dev veth1
   ip netns exec $NS2 ip addr add 10.10.10.2/24 dev veth2
+
+  # IPv6 outer addresses on veth
+  ip netns exec $NS1 ip -6 addr add 2001:db8:1::1/64 dev veth1
+  ip netns exec $NS2 ip -6 addr add 2001:db8:1::2/64 dev veth2
 
   ip netns exec $NS1 ip tuntap add dev tap1 mode tap
   ip netns exec $NS2 ip tuntap add dev tap2 mode tap
@@ -42,6 +49,10 @@ create() {
   ip netns exec $NS2 ip link set dev tap2 up
   ip netns exec $NS1 ip addr add 192.168.200.1/24 dev tap1
   ip netns exec $NS2 ip addr add 192.168.200.2/24 dev tap2
+
+  # IPv6 inner addresses on taps (used for ping6 test)
+  ip netns exec $NS1 ip -6 addr add 2001:db8:200::1/64 dev tap1
+  ip netns exec $NS2 ip -6 addr add 2001:db8:200::2/64 dev tap2
 
   echo "created namespaces and interfaces"
 }


### PR DESCRIPTION
#5 で頂いたパッチを変更し、IPv6 PMTU Discoveryは有効に戻した。